### PR TITLE
Adapters should now have underlying logger methods

### DIFF
--- a/adapter/log15adapter/log15adapter.go
+++ b/adapter/log15adapter/log15adapter.go
@@ -10,7 +10,7 @@ import (
 // Service is a logger.Service implementation, which is using `log15` package
 // (https://github.com/inconshreveable/log15).
 type Service struct {
-	log15.Logger
+	Logger log15.Logger
 }
 
 func (s Service) Log(ctx context.Context, entry logger.Entry) {

--- a/adapter/logrusadapter/logrus.go
+++ b/adapter/logrusadapter/logrus.go
@@ -9,7 +9,7 @@ import (
 
 // Service is a logger.Service implementation, which is using `logrus` module (https://github.com/sirupsen/logrus).
 type Service struct {
-	*logrus.Entry
+	Entry *logrus.Entry
 }
 
 func (s Service) Log(ctx context.Context, entry logger.Entry) {

--- a/adapter/printer/printer.go
+++ b/adapter/printer/printer.go
@@ -13,7 +13,7 @@ import (
 // Service is a logger.Service implementation, which is using Printer interface. This interface is implemented for
 // example by log.Logger from the Go standard library.
 type Service struct {
-	Printer
+	Printer Printer
 }
 
 type Printer interface {

--- a/adapter/zapadapter/zapadapter.go
+++ b/adapter/zapadapter/zapadapter.go
@@ -10,7 +10,7 @@ import (
 
 // Service is a logger.Service implementation, which is using `zap` module (https://github.com/uber-go/zap).
 type Service struct {
-	*zap.Logger
+	Logger *zap.Logger
 }
 
 func (s Service) Log(_ context.Context, entry logger.Entry) {

--- a/adapter/zerologadapter/zerolog.go
+++ b/adapter/zerologadapter/zerolog.go
@@ -9,11 +9,11 @@ import (
 
 // Service is a logger.Service implementation, which is using `zerolog` module (https://github.com/rs/zerolog).
 type Service struct {
-	zerolog.Logger
+	Logger zerolog.Logger
 }
 
 func (l Service) Log(ctx context.Context, entry logger.Entry) {
-	event := l.WithLevel(convertLevel(entry.Level))
+	event := l.Logger.WithLevel(convertLevel(entry.Level))
 
 	for _, field := range entry.Fields {
 		event = event.Interface(field.Key, field.Value)


### PR DESCRIPTION
Avoid embedding interfaces without name.