### PR TITLE
Remove formatting functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ But there are limitations for such solution:
 
 * even though your module will be independent of any specific logging implementation, you still have to import 
   `github.com/jacekolszak/yala/logger`. This package is relatively small though, compared to real logging libraries
-  (about ~260 lines of production code) and it does not import any external libraries.
+  (about ~240 lines of production code) and it does not import any external libraries.
 

--- a/adapter/contextservice/_example/main.go
+++ b/adapter/contextservice/_example/main.go
@@ -30,7 +30,7 @@ func main() {
 
 	logger.Debug(ctx, "Hello zap from ctx")
 	logger.With(ctx, "tag", "bbb").Info("Some info")
-	logger.Warnf(ctx, "Be careful with %s", "hot water")
+	logger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
 	logger.WithError(ctx, errors.New("ss")).Error("Some error")
 }
 

--- a/adapter/glogadapter/_example/main.go
+++ b/adapter/glogadapter/_example/main.go
@@ -19,6 +19,6 @@ func main() {
 
 	logger.Debug(ctx, "Hello glog ")
 	logger.With(ctx, "tag", "bbb").Info("Some info")
-	logger.Warnf(ctx, "Be careful with %s", "hot water")
+	logger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
 	logger.WithError(ctx, ErrSome).Error("Error occurred")
 }

--- a/adapter/log15adapter/_example/main.go
+++ b/adapter/log15adapter/_example/main.go
@@ -20,6 +20,6 @@ func main() {
 
 	logger.Debug(ctx, "Hello log15")
 	logger.With(ctx, "tag", "bbb").Info("Some info")
-	logger.Warnf(ctx, "Be careful with %s", "hot water")
+	logger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
 	logger.WithError(ctx, ErrSome).Error("Some error")
 }

--- a/adapter/logrusadapter/_example/main.go
+++ b/adapter/logrusadapter/_example/main.go
@@ -29,6 +29,6 @@ func main() {
 
 	logger.Debug(ctx, "Hello logrus ")
 	logger.With(ctx, "tag", "bbb").With("another", "ccc").Info("Some info")
-	logger.Warnf(ctx, "Be careful with %s", "hot water")
+	logger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
 	logger.WithError(ctx, ErrSome).Error("Some error")
 }

--- a/adapter/printer/_example/main.go
+++ b/adapter/printer/_example/main.go
@@ -17,7 +17,7 @@ func main() {
 
 	logger.Debug(ctx, "Hello fmt")
 	logger.With(ctx, "tag", "bbb").Info("Some info")
-	logger.Warnf(ctx, "Be careful with %s", "hot water")
+	logger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
 	logger.Error(ctx, "Some error")
 
 	// log using standard log package
@@ -27,6 +27,6 @@ func main() {
 
 	logger.Debug(ctx, "Hello stdlog")
 	logger.With(ctx, "tag", "bbb").Info("Some info")
-	logger.Warnf(ctx, "Be careful with %s", "hot water")
+	logger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
 	logger.Error(ctx, "Some error")
 }

--- a/adapter/zapadapter/_example/main.go
+++ b/adapter/zapadapter/_example/main.go
@@ -10,6 +10,8 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+var ErrSome = errors.New("ErrSome")
+
 func main() {
 	ctx := context.Background()
 
@@ -20,7 +22,7 @@ func main() {
 	logger.Debug(ctx, "Hello zap")
 	logger.With(ctx, "tag", "bbb").Info("Some info")
 	logger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	logger.WithError(ctx, errors.New("ss")).Error("Some error")
+	logger.WithError(ctx, ErrSome).Error("Some error")
 }
 
 func newZapLogger() *zap.Logger {

--- a/adapter/zapadapter/_example/main.go
+++ b/adapter/zapadapter/_example/main.go
@@ -19,7 +19,7 @@ func main() {
 
 	logger.Debug(ctx, "Hello zap")
 	logger.With(ctx, "tag", "bbb").Info("Some info")
-	logger.Warnf(ctx, "Be careful with %s", "hot water")
+	logger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
 	logger.WithError(ctx, errors.New("ss")).Error("Some error")
 }
 

--- a/adapter/zapadapter/zapadapter.go
+++ b/adapter/zapadapter/zapadapter.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/jacekolszak/yala/logger"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 // Service is a logger.Service implementation, which is using `zap` module (https://github.com/uber-go/zap).
@@ -25,13 +24,7 @@ func (s Service) Log(_ context.Context, entry logger.Entry) {
 	}
 
 	for _, f := range entry.Fields {
-		zapLogger = zapLogger.With(
-			zap.Field{
-				Key:       f.Key,
-				Interface: f.Value,
-				Type:      zapcore.StringType,
-			},
-		)
+		zapLogger = zapLogger.With(zap.Any(f.Key, f.Value))
 	}
 
 	zapLogger = zapLogger.WithOptions(zap.AddCallerSkip(entry.SkippedCallerFrames))

--- a/adapter/zerologadapter/_example/main.go
+++ b/adapter/zerologadapter/_example/main.go
@@ -19,6 +19,6 @@ func main() {
 
 	logger.Debug(ctx, "Hello zerolog")
 	logger.With(ctx, "tag", "bbb").Info("Some info")
-	logger.Warnf(ctx, "Be careful with %s", "hot water")
+	logger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
 	logger.WithError(ctx, errors.New("ss")).Error("Some error")
 }

--- a/logger/local.go
+++ b/logger/local.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"context"
-	"fmt"
 )
 
 const localLoggerSkippedCallerFrames = 2
@@ -25,32 +24,16 @@ func (l LocalLogger) Debug(ctx context.Context, msg string) {
 	l.service.Log(ctx, Entry{Level: DebugLevel, Message: msg, SkippedCallerFrames: localLoggerSkippedCallerFrames})
 }
 
-func (l LocalLogger) Debugf(ctx context.Context, format string, args ...interface{}) {
-	l.WithSkippedCallerFrame(ctx).Debug(fmt.Sprintf(format, args...))
-}
-
 func (l LocalLogger) Info(ctx context.Context, msg string) {
 	l.service.Log(ctx, Entry{Level: InfoLevel, Message: msg, SkippedCallerFrames: localLoggerSkippedCallerFrames})
-}
-
-func (l LocalLogger) Infof(ctx context.Context, format string, args ...interface{}) {
-	l.WithSkippedCallerFrame(ctx).Info(fmt.Sprintf(format, args...))
 }
 
 func (l LocalLogger) Warn(ctx context.Context, msg string) {
 	l.service.Log(ctx, Entry{Level: WarnLevel, Message: msg, SkippedCallerFrames: localLoggerSkippedCallerFrames})
 }
 
-func (l LocalLogger) Warnf(ctx context.Context, format string, args ...interface{}) {
-	l.WithSkippedCallerFrame(ctx).Warn(fmt.Sprintf(format, args...))
-}
-
 func (l LocalLogger) Error(ctx context.Context, msg string) {
 	l.service.Log(ctx, Entry{Level: ErrorLevel, Message: msg, SkippedCallerFrames: localLoggerSkippedCallerFrames})
-}
-
-func (l LocalLogger) Errorf(ctx context.Context, format string, args ...interface{}) {
-	l.WithSkippedCallerFrame(ctx).Error(fmt.Sprintf(format, args...))
 }
 
 // With creates a new Logger with field.

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -3,7 +3,6 @@ package logger
 
 import (
 	"context"
-	"fmt"
 )
 
 // Debug logs message using globally configured logger.Service.
@@ -15,19 +14,9 @@ func globalLoggerWithSkippedCallerFrame(ctx context.Context) Logger {
 	return getGlobalLogger().WithSkippedCallerFrame(ctx)
 }
 
-// Debugf logs message using globally configured logger.Service.
-func Debugf(ctx context.Context, format string, args ...interface{}) {
-	globalLoggerWithSkippedCallerFrame(ctx).Debugf(format, args...)
-}
-
 // Info logs message using globally configured logger.Service.
 func Info(ctx context.Context, msg string) {
 	globalLoggerWithSkippedCallerFrame(ctx).Info(msg)
-}
-
-// Infof logs message using globally configured logger.Service.
-func Infof(ctx context.Context, format string, args ...interface{}) {
-	globalLoggerWithSkippedCallerFrame(ctx).Infof(format, args...)
 }
 
 // Warn logs message using globally configured logger.Service.
@@ -35,19 +24,9 @@ func Warn(ctx context.Context, msg string) {
 	globalLoggerWithSkippedCallerFrame(ctx).Warn(msg)
 }
 
-// Warnf logs message using globally configured logger.Service.
-func Warnf(ctx context.Context, format string, args ...interface{}) {
-	globalLoggerWithSkippedCallerFrame(ctx).Warnf(format, args...)
-}
-
 // Error logs message using globally configured logger.Service.
 func Error(ctx context.Context, msg string) {
 	globalLoggerWithSkippedCallerFrame(ctx).Error(msg)
-}
-
-// Errorf logs message using globally configured logger.Service.
-func Errorf(ctx context.Context, format string, args ...interface{}) {
-	globalLoggerWithSkippedCallerFrame(ctx).Errorf(format, args...)
 }
 
 // With creates a new Logger with field and using globally configured logger.Service.
@@ -95,32 +74,16 @@ func (l Logger) Debug(msg string) {
 	l.log(DebugLevel, msg)
 }
 
-func (l Logger) Debugf(format string, args ...interface{}) {
-	l.WithSkippedCallerFrame().Debug(fmt.Sprintf(format, args...))
-}
-
 func (l Logger) Info(msg string) {
 	l.log(InfoLevel, msg)
-}
-
-func (l Logger) Infof(format string, args ...interface{}) {
-	l.WithSkippedCallerFrame().Info(fmt.Sprintf(format, args...))
 }
 
 func (l Logger) Warn(msg string) {
 	l.log(WarnLevel, msg)
 }
 
-func (l Logger) Warnf(format string, args ...interface{}) {
-	l.WithSkippedCallerFrame().Warn(fmt.Sprintf(format, args...))
-}
-
 func (l Logger) Error(msg string) {
 	l.log(ErrorLevel, msg)
-}
-
-func (l Logger) Errorf(format string, args ...interface{}) {
-	l.WithSkippedCallerFrame().Error(fmt.Sprintf(format, args...))
 }
 
 func (l Logger) log(level Level, msg string) {

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -3,7 +3,6 @@ package logger_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/jacekolszak/yala/logger"
@@ -47,35 +46,6 @@ func TestGlobalLogging(t *testing.T) {
 						Level:               lvl,
 						Message:             message,
 						SkippedCallerFrames: 4,
-					},
-				)
-			})
-		}
-	})
-
-	t.Run("should format message using global service", func(t *testing.T) {
-		type functionUnderTest func(ctx context.Context, fmt string, args ...interface{})
-		tests := map[logger.Level]functionUnderTest{
-			logger.DebugLevel: logger.Debugf,
-			logger.InfoLevel:  logger.Infof,
-			logger.WarnLevel:  logger.Warnf,
-			logger.ErrorLevel: logger.Errorf,
-		}
-
-		for lvl, log := range tests {
-			testName := string(lvl)
-
-			t.Run(testName, func(t *testing.T) {
-				service := &serviceMock{}
-				logger.SetService(service)
-				// when
-				log(ctx, fmt.Sprintf("formatted %s", "message"))
-				// then
-				service.HasExactlyOneEntry(t,
-					logger.Entry{
-						Level:               lvl,
-						Message:             "formatted message",
-						SkippedCallerFrames: 5,
 					},
 				)
 			})


### PR DESCRIPTION
The use of formatting functions (such as logger.Infof) does not fit well with structured logging. Developer should use fields instead of formatting messages by hand, because fields are better when searching. Also when messages are constants, they compress better. 