### PR TITLE
Rename Adapters method receivers from s to a

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ lib := NewLibrary(adapter)
 ```go
 type Adapter struct{}
 
-func (s Adapter) Log(ctx context.Context, entry logger.Entry) {
+func (Adapter) Log(context.Context, logger.Entry) {
     // here you can do whatever you want with the log entry 
 }
 ```

--- a/adapter/glogadapter/glog.go
+++ b/adapter/glogadapter/glog.go
@@ -12,7 +12,7 @@ type Adapter struct{}
 
 type log func(args ...interface{})
 
-func (s Adapter) Log(_ context.Context, entry logger.Entry) {
+func (a Adapter) Log(_ context.Context, entry logger.Entry) {
 	var logMessage log
 
 	switch entry.Level {

--- a/adapter/log15adapter/log15adapter.go
+++ b/adapter/log15adapter/log15adapter.go
@@ -13,12 +13,12 @@ type Adapter struct {
 	Logger log15.Logger
 }
 
-func (s Adapter) Log(ctx context.Context, entry logger.Entry) {
-	if s.Logger == nil {
+func (a Adapter) Log(ctx context.Context, entry logger.Entry) {
+	if a.Logger == nil {
 		return
 	}
 
-	log15Logger := s.Logger
+	log15Logger := a.Logger
 	for _, field := range entry.Fields {
 		log15Logger = log15Logger.New(field.Key, field.Value)
 	}

--- a/adapter/logrusadapter/logrus.go
+++ b/adapter/logrusadapter/logrus.go
@@ -12,8 +12,8 @@ type Adapter struct {
 	Entry *logrus.Entry
 }
 
-func (s Adapter) Log(ctx context.Context, entry logger.Entry) {
-	if s.Entry == nil {
+func (a Adapter) Log(ctx context.Context, entry logger.Entry) {
+	if a.Entry == nil {
 		return
 	}
 
@@ -30,7 +30,7 @@ func (s Adapter) Log(ctx context.Context, entry logger.Entry) {
 		lvl = logrus.ErrorLevel
 	}
 
-	logrusEntry := s.Entry
+	logrusEntry := a.Entry
 
 	for _, f := range entry.Fields {
 		logrusEntry = logrusEntry.WithField(f.Key, f.Value)

--- a/adapter/zapadapter/zapadapter.go
+++ b/adapter/zapadapter/zapadapter.go
@@ -12,12 +12,12 @@ type Adapter struct {
 	Logger *zap.Logger
 }
 
-func (s Adapter) Log(_ context.Context, entry logger.Entry) {
-	if s.Logger == nil {
+func (a Adapter) Log(_ context.Context, entry logger.Entry) {
+	if a.Logger == nil {
 		return
 	}
 
-	zapLogger := s.Logger
+	zapLogger := a.Logger
 
 	if entry.Error != nil {
 		zapLogger = zapLogger.With(zap.Error(entry.Error))

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -132,30 +132,30 @@ type adapterMock struct {
 	entries []logger.Entry
 }
 
-func (s *adapterMock) Log(_ context.Context, entry logger.Entry) {
-	s.entries = append(s.entries, entry)
+func (a *adapterMock) Log(_ context.Context, entry logger.Entry) {
+	a.entries = append(a.entries, entry)
 }
 
-func (s *adapterMock) HasExactlyOneEntry(t *testing.T, expected logger.Entry) {
+func (a *adapterMock) HasExactlyOneEntry(t *testing.T, expected logger.Entry) {
 	t.Helper()
 
-	require.Len(t, s.entries, 1)
-	actual := s.entries[0]
+	require.Len(t, a.entries, 1)
+	actual := a.entries[0]
 	assert.Equal(t, expected, actual)
 }
 
-func (s *adapterMock) HasExactlyOneEntryWithFields(t *testing.T, expected []logger.Field) {
+func (a *adapterMock) HasExactlyOneEntryWithFields(t *testing.T, expected []logger.Field) {
 	t.Helper()
 
-	require.Len(t, s.entries, 1)
-	actual := s.entries[0].Fields
+	require.Len(t, a.entries, 1)
+	actual := a.entries[0].Fields
 	assert.Equal(t, expected, actual)
 }
 
-func (s *adapterMock) HasExactlyOneEntryWithError(t *testing.T, expected error) {
+func (a *adapterMock) HasExactlyOneEntryWithError(t *testing.T, expected error) {
 	t.Helper()
 
-	require.Len(t, s.entries, 1)
-	actual := s.entries[0].Error
+	require.Len(t, a.entries, 1)
+	actual := a.entries[0].Error
 	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
This change does not modify API, just internal details.