### PR TITLE
Refactor contextadapter

### DIFF
--- a/adapter/contextadapter/contextadapter.go
+++ b/adapter/contextadapter/contextadapter.go
@@ -6,23 +6,21 @@ import (
 	"github.com/jacekolszak/yala/logger"
 )
 
-func New(contextKey interface{}, a logger.Adapter) logger.Adapter { // nolint
+func New(contextKey interface{}, adapterFromContextLogger func(loggerOrNil interface{}) logger.Adapter) logger.Adapter { // nolint
 	return adapter{
-		adapter:    a,
-		contextKey: contextKey,
+		contextKey:               contextKey,
+		adapterFromContextLogger: adapterFromContextLogger,
 	}
 }
 
 type adapter struct {
-	adapter    logger.Adapter
-	contextKey interface{}
+	contextKey               interface{}
+	adapterFromContextLogger func(loggerOrNil interface{}) logger.Adapter
 }
 
 func (p adapter) Log(ctx context.Context, entry logger.Entry) {
-	loggerAdapter, ok := ctx.Value(p.contextKey).(logger.Adapter)
-	if !ok {
-		loggerAdapter = p.adapter
-	}
+	contextLogger := ctx.Value(p.contextKey)
+	loggerAdapter := p.adapterFromContextLogger(contextLogger)
 
 	newEntry := entry
 	newEntry.SkippedCallerFrames++

--- a/adapter/glogadapter/_example/main.go
+++ b/adapter/glogadapter/_example/main.go
@@ -14,10 +14,10 @@ var ErrSome = errors.New("ErrSome")
 func main() {
 	ctx := context.Background()
 
-	flag.Parse()                             // glog does not work without parsing the flags first
+	flag.Parse()                             // glog will pick command line options like -stderrthreshold=[INFO|WARNING|ERROR]
 	logger.SetAdapter(glogadapter.Adapter{}) // set glog adapter globally
 
-	logger.Debug(ctx, "Hello glog ")
+	logger.Debug(ctx, "Hello glog ") // Debug will be logged as Info
 	logger.With(ctx, "field_name", "field_value").Info("Some info")
 	logger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
 	logger.WithError(ctx, ErrSome).Error("Error occurred")


### PR DESCRIPTION
Current implementation of contextadapter is too limiting. It does not support passing all kinds of loggers via context (only yala adapter).  But in reality many applications use their own implementations.

This commit ads possibility to specify custom behaviour for extracting logger.Adapter out of  context.Context.