### PR TITLE
Add warning that no global logger is set

### DIFF
--- a/logger/adapter.go
+++ b/logger/adapter.go
@@ -46,7 +46,7 @@ type Field struct {
 }
 
 func init() {
-	SetAdapter(noopLogger{})
+	SetAdapter(&initialNoopLogger{})
 }
 
 var globalLogger atomic.Value

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -32,6 +32,10 @@ func TestGlobalLogging(t *testing.T) {
 		logger.Info(ctx, message)
 	})
 
+	t.Run("should log warning that global adapter was not set", func(t *testing.T) {
+		logger.Warn(ctx, message)
+	})
+
 	t.Run("should log message using global adapter", func(t *testing.T) {
 		type functionUnderTest func(ctx context.Context, msg string)
 		tests := map[logger.Level]functionUnderTest{

--- a/logger/noop.go
+++ b/logger/noop.go
@@ -2,8 +2,22 @@ package logger
 
 import (
 	"context"
+	"fmt"
+	"sync"
 )
 
 type noopLogger struct{}
 
 func (n noopLogger) Log(context.Context, Entry) {}
+
+var once sync.Once
+
+type initialNoopLogger struct{}
+
+func (g *initialNoopLogger) Log(_ context.Context, entry Entry) {
+	if entry.Level == WarnLevel || entry.Level == ErrorLevel {
+		once.Do(func() {
+			fmt.Printf("github.com/jacekolszak/yala/logger cannot log message with level %s. Please set the global logging adapter. For example: logger.SetAdapter(printer.StdoutAdapter()) to log all messages to stdout.\n", entry.Level) // nolint
+		})
+	}
+}


### PR DESCRIPTION
Print warning message that global logger was not set. This is a hint for the library user, that the lib is trying to log something, but logging is disabled.