### PR TITLE
[refactor] create global logger

### DIFF
--- a/logger/adapter.go
+++ b/logger/adapter.go
@@ -2,19 +2,12 @@ package logger
 
 import (
 	"context"
-	"sync/atomic"
 )
 
 // SetAdapter sets a global adapter implementation used by logging functions in the logger package,
 // such as `logger.Info`. By default, nothing is logged.
 func SetAdapter(adapter Adapter) {
-	if adapter == nil {
-		adapter = noopLogger{}
-	}
-
-	globalLogger.Store(
-		LocalLogger{adapter: adapter},
-	)
+	globalLogger.SetAdapter(adapter)
 }
 
 // Adapter is an interface to be implemented by logger adapters.
@@ -49,8 +42,4 @@ func init() {
 	SetAdapter(&initialGlobalNoopLogger{})
 }
 
-var globalLogger atomic.Value
-
-func getGlobalLogger() LocalLogger {
-	return globalLogger.Load().(LocalLogger)
-}
+var globalLogger global

--- a/logger/global.go
+++ b/logger/global.go
@@ -1,0 +1,56 @@
+package logger
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+type global struct {
+	logger atomic.Value
+}
+
+func (g *global) SetAdapter(adapter Adapter) {
+	if adapter == nil {
+		adapter = noopLogger{}
+	}
+
+	g.logger.Store(LocalLogger{adapter: adapter})
+}
+
+func (g *global) getLogger() LocalLogger {
+	return g.logger.Load().(LocalLogger)
+}
+
+// Debug logs message using globally configured logger.Adapter.
+func (g *global) Debug(ctx context.Context, msg string) {
+	g.loggerWithSkippedCallerFrame(ctx).Debug(msg)
+}
+
+func (g *global) loggerWithSkippedCallerFrame(ctx context.Context) Logger {
+	return g.getLogger().WithSkippedCallerFrame(ctx).WithSkippedCallerFrame()
+}
+
+// Info logs message using globally configured logger.Adapter.
+func (g *global) Info(ctx context.Context, msg string) {
+	g.loggerWithSkippedCallerFrame(ctx).Info(msg)
+}
+
+// Warn logs message using globally configured logger.Adapter.
+func (g *global) Warn(ctx context.Context, msg string) {
+	g.loggerWithSkippedCallerFrame(ctx).Warn(msg)
+}
+
+// Error logs message using globally configured logger.Adapter.
+func (g *global) Error(ctx context.Context, msg string) {
+	g.loggerWithSkippedCallerFrame(ctx).Error(msg)
+}
+
+// With creates a new Logger with field and using globally configured logger.Adapter.
+func (g *global) With(ctx context.Context, key string, value interface{}) Logger {
+	return g.getLogger().With(ctx, key, value)
+}
+
+// WithError creates a new Logger with error and using globally configured logger.Adapter.
+func (g *global) WithError(ctx context.Context, err error) Logger {
+	return g.getLogger().WithError(ctx, err)
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -16,36 +16,32 @@ import (
 
 // Debug logs message using globally configured logger.Adapter.
 func Debug(ctx context.Context, msg string) {
-	globalLoggerWithSkippedCallerFrame(ctx).Debug(msg)
-}
-
-func globalLoggerWithSkippedCallerFrame(ctx context.Context) Logger {
-	return getGlobalLogger().WithSkippedCallerFrame(ctx)
+	globalLogger.Debug(ctx, msg)
 }
 
 // Info logs message using globally configured logger.Adapter.
 func Info(ctx context.Context, msg string) {
-	globalLoggerWithSkippedCallerFrame(ctx).Info(msg)
+	globalLogger.Info(ctx, msg)
 }
 
 // Warn logs message using globally configured logger.Adapter.
 func Warn(ctx context.Context, msg string) {
-	globalLoggerWithSkippedCallerFrame(ctx).Warn(msg)
+	globalLogger.Warn(ctx, msg)
 }
 
 // Error logs message using globally configured logger.Adapter.
 func Error(ctx context.Context, msg string) {
-	globalLoggerWithSkippedCallerFrame(ctx).Error(msg)
+	globalLogger.Error(ctx, msg)
 }
 
 // With creates a new Logger with field and using globally configured logger.Adapter.
 func With(ctx context.Context, key string, value interface{}) Logger {
-	return getGlobalLogger().With(ctx, key, value)
+	return globalLogger.With(ctx, key, value)
 }
 
 // WithError creates a new Logger with error and using globally configured logger.Adapter.
 func WithError(ctx context.Context, err error) Logger {
-	return getGlobalLogger().WithError(ctx, err)
+	return globalLogger.WithError(ctx, err)
 }
 
 type Logger struct {

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -58,7 +58,7 @@ func TestGlobalLogging(t *testing.T) {
 					logger.Entry{
 						Level:               lvl,
 						Message:             message,
-						SkippedCallerFrames: 4,
+						SkippedCallerFrames: 5,
 					},
 				)
 			})


### PR DESCRIPTION
This change does not break the API.

The new logger.global struct is a logger which adapter can be changed anytime.