### PR TITLE
[breaking change] Create logger.Global logger

### DIFF
--- a/adapter/contextadapter/_example/main.go
+++ b/adapter/contextadapter/_example/main.go
@@ -31,17 +31,17 @@ func main() {
 
 		return zapadapter.Adapter{Logger: defaultZapLogger}
 	})
-	// set it globally
-	logger.SetAdapter(adapter)
+	// create local logger
+	yalaLogger := logger.Local(adapter)
 
 	contextLogger := defaultZapLogger.With(zap.String("tag", "value"))
 	// bind zap logger to ctx, so all messages will be logged with tag
 	ctx = context.WithValue(ctx, contextLoggerKey, contextLogger)
 
-	logger.Debug(ctx, "Hello zap from ctx")
-	logger.With(ctx, "field_name", "field_value").Info("Some info")
-	logger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	logger.WithError(ctx, ErrSome).Error("Some error")
+	yalaLogger.Debug(ctx, "Hello zap from ctx")
+	yalaLogger.With(ctx, "field_name", "field_value").Info("Some info")
+	yalaLogger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
+	yalaLogger.WithError(ctx, ErrSome).Error("Some error")
 }
 
 func newZapLogger() *zap.Logger {

--- a/adapter/glogadapter/_example/main.go
+++ b/adapter/glogadapter/_example/main.go
@@ -15,11 +15,12 @@ var ErrSome = errors.New("ErrSome")
 func main() {
 	ctx := context.Background()
 
-	flag.Parse()                             // glog will pick command line options like -stderrthreshold=[INFO|WARNING|ERROR]
-	logger.SetAdapter(glogadapter.Adapter{}) // set glog adapter globally
+	flag.Parse() // glog will pick command line options like -stderrthreshold=[INFO|WARNING|ERROR]
+	// create local logger
+	yalaLogger := logger.Local(glogadapter.Adapter{})
 
-	logger.Debug(ctx, "Hello glog ") // Debug will be logged as Info
-	logger.With(ctx, "field_name", "field_value").Info("Some info")
-	logger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	logger.WithError(ctx, ErrSome).Error("Error occurred")
+	yalaLogger.Debug(ctx, "Hello glog ") // Debug will be logged as Info
+	yalaLogger.With(ctx, "field_name", "field_value").Info("Some info")
+	yalaLogger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
+	yalaLogger.WithError(ctx, ErrSome).Error("Error occurred")
 }

--- a/adapter/internal/benchmark/benchmark.go
+++ b/adapter/internal/benchmark/benchmark.go
@@ -13,13 +13,14 @@ func Adapter(b *testing.B, adapter logger.Adapter) {
 	ctx := context.Background()
 
 	b.Run("global logger info", func(b *testing.B) {
-		logger.SetAdapter(adapter)
+		var global logger.Global
+		global.SetAdapter(adapter)
 
 		b.ReportAllocs()
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			logger.Info(ctx, "msg")
+			global.Info(ctx, "msg")
 		}
 	})
 

--- a/adapter/log15adapter/_example/main.go
+++ b/adapter/log15adapter/_example/main.go
@@ -17,10 +17,10 @@ func main() {
 
 	l := log15.New()                           // create log15 logger
 	adapter := log15adapter.Adapter{Logger: l} // create logger.Adapter for log15
-	logger.SetAdapter(adapter)                 // set log15 it globally
+	yalaLogger := logger.Local(adapter)        // create yala logger
 
-	logger.Debug(ctx, "Hello log15")
-	logger.With(ctx, "field_name", "field_value").Info("Some info")
-	logger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	logger.WithError(ctx, ErrSome).Error("Some error")
+	yalaLogger.Debug(ctx, "Hello log15")
+	yalaLogger.With(ctx, "field_name", "field_value").Info("Some info")
+	yalaLogger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
+	yalaLogger.WithError(ctx, ErrSome).Error("Some error")
 }

--- a/adapter/logrusadapter/_example/main.go
+++ b/adapter/logrusadapter/_example/main.go
@@ -21,13 +21,13 @@ func main() {
 	adapter := logrusadapter.Adapter{
 		Entry: entry, // inject logrus
 	}
-	// And use adapter globally
-	logger.SetAdapter(adapter)
+	// Create yala logger
+	yalaLogger := logger.Local(adapter)
 
-	logger.Debug(ctx, "Hello logrus ")
-	logger.With(ctx, "field_name", "field_value").With("another", "ccc").Info("Some info")
-	logger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	logger.WithError(ctx, ErrSome).Error("Some error")
+	yalaLogger.Debug(ctx, "Hello logrus ")
+	yalaLogger.With(ctx, "field_name", "field_value").With("another", "ccc").Info("Some info")
+	yalaLogger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
+	yalaLogger.WithError(ctx, ErrSome).Error("Some error")
 }
 
 func newLogrusEntry() *logrus.Entry {

--- a/adapter/printer/_example/main.go
+++ b/adapter/printer/_example/main.go
@@ -17,20 +17,20 @@ func main() {
 	ctx := context.Background()
 
 	// log using fmt.Println
-	logger.SetAdapter(printer.StdoutAdapter())
+	yalaLogger := logger.Local(printer.StdoutAdapter())
 
-	logger.Debug(ctx, "Hello fmt")
-	logger.With(ctx, "field_name", "field_value").Info("Some info")
-	logger.With(ctx, "parameter", "some value").Warn("Deprecated configuration parameter. It will be removed.")
-	logger.WithError(ctx, ErrSome).Error("Some error")
+	yalaLogger.Debug(ctx, "Hello fmt")
+	yalaLogger.With(ctx, "field_name", "field_value").Info("Some info")
+	yalaLogger.With(ctx, "parameter", "some value").Warn("Deprecated configuration parameter. It will be removed.")
+	yalaLogger.WithError(ctx, ErrSome).Error("Some error")
 
 	// log using standard log package
 	standardLog := log.New(os.Stdout, "", log.LstdFlags)
 	adapter := printer.Adapter{Printer: standardLog}
-	logger.SetAdapter(adapter)
+	yalaLogger = logger.Local(adapter)
 
-	logger.Debug(ctx, "Hello standard log")
-	logger.With(ctx, "f1", "v1").With("f2", "f2").Info("Some info")
-	logger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	logger.WithError(ctx, ErrSome).Error("Some error")
+	yalaLogger.Debug(ctx, "Hello standard log")
+	yalaLogger.With(ctx, "f1", "v1").With("f2", "f2").Info("Some info")
+	yalaLogger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
+	yalaLogger.WithError(ctx, ErrSome).Error("Some error")
 }

--- a/adapter/zapadapter/_example/main.go
+++ b/adapter/zapadapter/_example/main.go
@@ -18,12 +18,12 @@ func main() {
 
 	zapLogger := newZapLogger()
 	adapter := zapadapter.Adapter{Logger: zapLogger} // create logger.Adapter for zap
-	logger.SetAdapter(adapter)                       // set it globally
+	yalaLogger := logger.Local(adapter)              // Create yala logger
 
-	logger.Debug(ctx, "Hello zap")
-	logger.With(ctx, "field_name", "field_value").Info("Some info")
-	logger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	logger.WithError(ctx, ErrSome).Error("Some error")
+	yalaLogger.Debug(ctx, "Hello zap")
+	yalaLogger.With(ctx, "field_name", "field_value").Info("Some info")
+	yalaLogger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
+	yalaLogger.WithError(ctx, ErrSome).Error("Some error")
 }
 
 func newZapLogger() *zap.Logger {

--- a/adapter/zerologadapter/_example/main.go
+++ b/adapter/zerologadapter/_example/main.go
@@ -18,10 +18,10 @@ func main() {
 
 	l := zerolog.New(os.Stdout)                  // create zerolog logger
 	adapter := zerologadapter.Adapter{Logger: l} // create logger.Adapter for zerolog
-	logger.SetAdapter(adapter)                   // set it globally
+	yalaLogger := logger.Local(adapter)          // Create yala logger
 
-	logger.Debug(ctx, "Hello zerolog")
-	logger.With(ctx, "field_name", "field_value").Info("Some info")
-	logger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	logger.WithError(ctx, ErrSome).Error("Some error")
+	yalaLogger.Debug(ctx, "Hello zerolog")
+	yalaLogger.With(ctx, "field_name", "field_value").Info("Some info")
+	yalaLogger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
+	yalaLogger.WithError(ctx, ErrSome).Error("Some error")
 }

--- a/logger/adapter.go
+++ b/logger/adapter.go
@@ -4,12 +4,6 @@ import (
 	"context"
 )
 
-// SetAdapter sets a global adapter implementation used by logging functions in the logger package,
-// such as `logger.Info`. By default, nothing is logged.
-func SetAdapter(adapter Adapter) {
-	globalLogger.SetAdapter(adapter)
-}
-
 // Adapter is an interface to be implemented by logger adapters.
 type Adapter interface {
 	Log(context.Context, Entry)
@@ -37,9 +31,3 @@ type Field struct {
 	Key   string
 	Value interface{}
 }
-
-func init() {
-	SetAdapter(&initialGlobalNoopLogger{})
-}
-
-var globalLogger global

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -14,36 +14,6 @@ import (
 	"context"
 )
 
-// Debug logs message using globally configured logger.Adapter.
-func Debug(ctx context.Context, msg string) {
-	globalLogger.Debug(ctx, msg)
-}
-
-// Info logs message using globally configured logger.Adapter.
-func Info(ctx context.Context, msg string) {
-	globalLogger.Info(ctx, msg)
-}
-
-// Warn logs message using globally configured logger.Adapter.
-func Warn(ctx context.Context, msg string) {
-	globalLogger.Warn(ctx, msg)
-}
-
-// Error logs message using globally configured logger.Adapter.
-func Error(ctx context.Context, msg string) {
-	globalLogger.Error(ctx, msg)
-}
-
-// With creates a new Logger with field and using globally configured logger.Adapter.
-func With(ctx context.Context, key string, value interface{}) Logger {
-	return globalLogger.With(ctx, key, value)
-}
-
-// WithError creates a new Logger with error and using globally configured logger.Adapter.
-func WithError(ctx context.Context, err error) Logger {
-	return globalLogger.WithError(ctx, err)
-}
-
 // Logger is an immutable struct to log messages or create new loggers with fields or error.
 //
 // It is safe to use it concurrently.

--- a/logger/logger_bench_test.go
+++ b/logger/logger_bench_test.go
@@ -10,13 +10,16 @@ func BenchmarkInfo(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 
+	var global logger.Global
+
 	for i := 0; i < b.N; i++ {
-		logger.Info(ctx, "msg") // 30ns, 0 allocs
+		global.Info(ctx, "msg") // 30ns, 0 allocs
 	}
 }
 
 func BenchmarkLogger_Info(b *testing.B) {
-	loggerWithField := logger.With(ctx, "k", "v")
+	var global logger.Global
+	loggerWithField := global.With(ctx, "k", "v")
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -30,8 +33,10 @@ func BenchmarkWith(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 
+	var global logger.Global
+
 	for i := 0; i < b.N; i++ {
-		_ = logger.With(ctx, "k", "v") // 55ns, 1 alloc
+		_ = global.With(ctx, "k", "v") // 55ns, 1 alloc
 	}
 }
 
@@ -39,7 +44,9 @@ func BenchmarkWithError(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 
+	var global logger.Global
+
 	for i := 0; i < b.N; i++ {
-		_ = logger.WithError(ctx, ErrSome) // 15ns, 0 allocs
+		_ = global.WithError(ctx, ErrSome) // 15ns, 0 allocs
 	}
 }

--- a/logger/logger_concurrency_test.go
+++ b/logger/logger_concurrency_test.go
@@ -12,7 +12,8 @@ import (
 func TestConcurrency(t *testing.T) {
 	t.Run("global log functions", func(t *testing.T) {
 		adapter := &concurrencySafeAdapter{}
-		logger.SetAdapter(adapter)
+		var global logger.Global
+		global.SetAdapter(adapter)
 
 		var wg sync.WaitGroup
 
@@ -21,12 +22,12 @@ func TestConcurrency(t *testing.T) {
 
 			go func() {
 				// when
-				logger.Debug(ctx, message)
-				logger.Info(ctx, message)
-				logger.Warn(ctx, message)
-				logger.Error(ctx, message)
-				logger.With(ctx, "k", "v").Info(message)
-				logger.WithError(ctx, ErrSome).Error(message)
+				global.Debug(ctx, message)
+				global.Info(ctx, message)
+				global.Warn(ctx, message)
+				global.Error(ctx, message)
+				global.With(ctx, "k", "v").Info(message)
+				global.WithError(ctx, ErrSome).Error(message)
 				wg.Done()
 			}()
 		}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -28,21 +28,25 @@ var loggerMethods = map[string]loggerMethod{
 
 func TestGlobalLogging(t *testing.T) {
 	t.Run("passing nil global adapter should disable logger", func(t *testing.T) {
-		logger.SetAdapter(nil)
-		logger.Info(ctx, message)
+		var global logger.Global
+		global.SetAdapter(nil)
+		global.Info(ctx, message)
 	})
 
 	t.Run("should log warning that global adapter was not set", func(t *testing.T) {
-		logger.Warn(ctx, message)
+		var global logger.Global
+		global.Warn(ctx, message)
 	})
 
 	t.Run("should log message using global adapter", func(t *testing.T) {
+		var global logger.Global
+
 		type functionUnderTest func(ctx context.Context, msg string)
 		tests := map[logger.Level]functionUnderTest{
-			logger.DebugLevel: logger.Debug,
-			logger.InfoLevel:  logger.Info,
-			logger.WarnLevel:  logger.Warn,
-			logger.ErrorLevel: logger.Error,
+			logger.DebugLevel: global.Debug,
+			logger.InfoLevel:  global.Info,
+			logger.WarnLevel:  global.Warn,
+			logger.ErrorLevel: global.Error,
 		}
 
 		for lvl, log := range tests {
@@ -50,7 +54,7 @@ func TestGlobalLogging(t *testing.T) {
 
 			t.Run(testName, func(t *testing.T) {
 				adapter := &adapterMock{}
-				logger.SetAdapter(adapter)
+				global.SetAdapter(adapter)
 				// when
 				log(ctx, message)
 				// then
@@ -107,9 +111,10 @@ func TestWith(t *testing.T) {
 
 	loggersWithField := map[string]newLoggerWithField{
 		"global": func(adapter logger.Adapter, field logger.Field) logger.Logger {
-			logger.SetAdapter(adapter)
+			var global logger.Global
+			global.SetAdapter(adapter)
 
-			return logger.With(ctx, field.Key, field.Value)
+			return global.With(ctx, field.Key, field.Value)
 		},
 		"local": func(adapter logger.Adapter, field logger.Field) logger.Logger {
 			return logger.Local(adapter).With(ctx, field.Key, field.Value)
@@ -166,9 +171,10 @@ func TestWithError(t *testing.T) {
 
 	loggersWithError := map[string]newLoggerWithError{
 		"global": func(adapter logger.Adapter, err error) logger.Logger {
-			logger.SetAdapter(adapter)
+			var global logger.Global
+			global.SetAdapter(adapter)
 
-			return logger.WithError(ctx, err)
+			return global.WithError(ctx, err)
 		},
 		"local": func(adapter logger.Adapter, err error) logger.Logger {
 			return logger.Local(adapter).WithError(ctx, err)


### PR DESCRIPTION
This struct is useful for defining global loggers in your libaries.

This commit also removes global logger from logger package. Sharing logger between multiple libraries have limitations:

* no way to disable logging for particular libs
* no way to provide different fields for particular libs (for example the name of logger)