### PR TITLE
[github] Run Go tests using multiple versions of Go

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,17 +9,17 @@ on:
 jobs:
 
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        os: [ ubuntu-20.04, windows-2022, macos-11 ]
+        go: [ 1.13, 1.14, 1.15, 1.16, 1.17 ]
     steps:
       - uses: actions/checkout@v2
 
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: ${{ matrix.go }}
 
       - name: Test
         run: make test


### PR DESCRIPTION
Using 3 different operating systems does not really make sense, because yala is not using os-specific calls. It will be better to support multiple versions of Go instead.